### PR TITLE
Bump version to 0.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bh, pdu = bha.encode_blurhash_and_pda(avif_path, x_components=4, y_components=4,
 print("got both ->", bool(bh), bool(pdu))
 
 # 4) Batch: all .avif files in a directory
-results = bha.batch_encode("assets/")            # returns dict(filename -> blurhash_or_None)
+results: dict[str, Optional[str]] = bha.batch_encode("assets/") # returns dict(filename -> blurhash_or_None)
 valid_files = [name for name, h in results.items() if h]
 print("Valid blurhash files:", ", ".join(valid_files) or "<none>")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "blurhash-avif"
-version = "0.8.4"
+version = "0.8.5"
 description = "A library to generate BlurHash and PNG data URLs for AVIF images"
 readme = "README.md"
 readme-content-type = "text/markdown"
@@ -62,7 +62,7 @@ select = [
   "SIM", "NPY", "PD", "ARG", "TID", "PTH", "ISC", "PIE", "YTT", "ASYNC", "C4",
   "T10", "COM", "RSE", "PGH", "PLR", "PLC", "PGH", "FURB", "PLW", "TRY", "PERF",
   "EXE", "DTZ", "INT", "ISC", "ICN", "LOG", "FLY", "EM", "SLF", "SLOT",
-  "BLE", "ANN", "TC",
+  "BLE", "ANN", "TC", "FBT"
 ]
 ignore = [
   "PLR0913", "PLR0911", "PLR0914", "PLR6301", "E501", "G004", "RUF100",

--- a/src/blurhash_avif/__init__.py
+++ b/src/blurhash_avif/__init__.py
@@ -1,5 +1,6 @@
 # src/blurhash_avif/__init__.py
 from .blurhash_avif import (
+    MAX_AVIF_IMAGE_EDGE_SIZE,
     AvifPngDataUrlError,
     BlurHashAvifError,
     BlurHashDecodeError,
@@ -20,6 +21,7 @@ from .blurhash_avif import (
 )
 
 __all__ = [
+    "MAX_AVIF_IMAGE_EDGE_SIZE",
     "AvifPngDataUrlError",
     "BlurHashAvifError",
     "BlurHashDecodeError",

--- a/src/blurhash_avif/__init__.py
+++ b/src/blurhash_avif/__init__.py
@@ -6,6 +6,8 @@ from .blurhash_avif import (
     BlurHashEncodeError,
     ImageSaveError,
     PathError,
+    ResamplingMethod,
+    _simple_blurhash_validation,
     batch_encode,
     batch_encode_blurhash_and_pdu,
     batch_encode_pdu,
@@ -14,7 +16,6 @@ from .blurhash_avif import (
     encode,
     encode_blurhash_and_pdu,
     encode_pdu,
-    is_valid_blurhash,
     save_image_png,
 )
 
@@ -25,6 +26,8 @@ __all__ = [
     "BlurHashEncodeError",
     "ImageSaveError",
     "PathError",
+    "ResamplingMethod",
+    "_simple_blurhash_validation",
     "batch_encode",
     "batch_encode_blurhash_and_pdu",
     "batch_encode_pdu",
@@ -33,6 +36,5 @@ __all__ = [
     "encode",
     "encode_blurhash_and_pdu",
     "encode_pdu",
-    "is_valid_blurhash",
     "save_image_png",
 ]

--- a/src/blurhash_avif/blurhash_avif.py
+++ b/src/blurhash_avif/blurhash_avif.py
@@ -528,13 +528,13 @@ def _simple_blurhash_validation(blurhash_string: str) -> bool:
     return all(c in valid_chars for c in blurhash_string)
 
 
-def decode_to_pil_format(blurhash_string: str, width: float, height: float, punch: float = 1.0) -> PILImage:
+def decode_to_pil_format(blurhash_string: str, width: int, height: int, punch: float = 1.0) -> PILImage:
     """Decode a BlurHash string into a PIL Image object.
 
     Args:
         blurhash_string (str): The BlurHash string to decode.
-        width (float): The desired width of the output image (must be positive).
-        height (float): The desired height of the output image (must be positive).
+        width (int): The desired width of the output image (must be positive).
+        height (int): The desired height of the output image (must be positive).
         punch (float): Contrast adjustment factor (default: 1.0).
                     - Values < 1.0 reduce contrast (softer, more blurred)
                     - Values > 1.0 increase contrast (sharper, more defined)
@@ -639,8 +639,8 @@ def decode(  # noqa: PLR0917
     output_path: str | Path,
     blurhash_string: str,
     filename: str = "output.png",
-    width: float = 400,
-    height: float = 300,
+    width: int = 400,
+    height: int = 300,
     punch: float = 1.0,
     optimize: bool = True,  # noqa: FBT001, FBT002
     interlaced: bool = True,  # noqa: FBT001, FBT002
@@ -651,8 +651,8 @@ def decode(  # noqa: PLR0917
         output_path (str | Path): Directory where the decoded image will be saved.
         blurhash_string (str): The BlurHash string to decode.
         filename (str): Output filename (default: "output.png").
-        width (float): Output image width in pixels (default: 400).
-        height (float): Output image height in pixels (default: 300).
+        width (int): Output image width in pixels (default: 400).
+        height (int): Output image height in pixels (default: 300).
         punch (float): Contrast adjustment factor (default: 1.0).
                     - Values < 1.0 reduce contrast (softer, more blurred)
                     - Values > 1.0 increase contrast (sharper, more defined)

--- a/src/blurhash_avif/blurhash_avif.py
+++ b/src/blurhash_avif/blurhash_avif.py
@@ -208,8 +208,7 @@ def _encode_pdu_from_image(
 
     Raises:
         AvifPngDataUrlError: If encoding fails or dimensions are invalid.
-        ValueError: If max_dimension is not positive, If max_dimension is not positive,
-        or if the resampling method value is invalid.
+        ValueError: If max_dimension is not positive or if the resampling method value is invalid.
     """
     # Validate max_dimension
     if max_dimension <= 0:
@@ -597,8 +596,8 @@ def save_image_png(image: PILImage, filename: str | Path, *, optimize: bool = Tr
         ValueError: If the image or filename is invalid.
         ImageSaveError: If the image cannot be saved.
     """
-    if not image:
-        msg = "Image cannot be empty"
+    if image is None:
+        msg = "Image cannot be of type None"
         raise ValueError(msg)
 
     if not filename:

--- a/src/blurhash_avif/blurhash_avif.py
+++ b/src/blurhash_avif/blurhash_avif.py
@@ -13,7 +13,7 @@ import base64
 import contextlib
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 import blurhash
 import numpy as np
@@ -23,8 +23,9 @@ from PIL import Image
 if TYPE_CHECKING:
     from PIL.Image import Image as PILImage
 
-
+MAX_AVIF_IMAGE_EDGE_SIZE = 65_536
 MAX_COMPONENTS_SIZE = 9
+ResamplingMethod = Literal["lanczos", "nearest", "bilinear", "bicubic"]
 
 
 class BlurHashAvifError(Exception):
@@ -51,7 +52,7 @@ class ImageSaveError(BlurHashAvifError):
     """Exception raised when saving an image fails."""
 
 
-def _validate_and_resolve_path(image_path: str | Path, require_avif: bool = False) -> Path:
+def _validate_and_resolve_path(image_path: str | Path, *, require_avif: bool = False) -> Path:
     """Validate and convert image_path to a Path object.
 
     Args:
@@ -85,48 +86,93 @@ def _validate_and_resolve_path(image_path: str | Path, require_avif: bool = Fals
     return path_obj
 
 
-def _resize_image_if_needed(image: PILImage, max_dimension: int) -> PILImage:
-    """Resize image to fit within max_dimension while maintaining aspect ratio.
+def _downsample_image_if_needed(
+    image: PILImage, max_dimension: float, resampling_method: ResamplingMethod = "lanczos"
+) -> PILImage:
+    """Downsample the image if its dimensions exceed the maximum dimension.
+
+    Args:
+        image (PILImage): The input image.
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension.
+        resampling_method (ResamplingMethod): The resampling method to use.
 
     Returns:
-        PILImage: Resized image or original if already within bounds.
+        PILImage: The possible downsampled image.
+
+    Raises:
+        ValueError: If max_dimension is not positive or if the resampling method is invalid.
     """
+    if max_dimension <= 0:
+        msg = f"max_dimension must be positive, got {max_dimension}"
+        raise ValueError(msg)
+    if max_dimension > MAX_AVIF_IMAGE_EDGE_SIZE:
+        msg = f"max_dimension must be less than or equal to {MAX_AVIF_IMAGE_EDGE_SIZE}, got {max_dimension}"
+        raise ValueError(msg)
+
+    resample_map = {
+        "lanczos": Image.Resampling.LANCZOS,
+        "nearest": Image.Resampling.NEAREST,
+        "bilinear": Image.Resampling.BILINEAR,
+        "bicubic": Image.Resampling.BICUBIC,
+    }
+    try:
+        resampling_method_id = resample_map[resampling_method]
+    except KeyError as e:
+        msg = f"Unknown resampling_method: {resampling_method!r}"
+        raise ValueError(msg) from e
+
     if image.width <= max_dimension and image.height <= max_dimension:
         return image
 
-    scale = max(image.width, image.height) / float(max_dimension)
-    new_width = max(1, round(image.width / scale))
-    new_height = max(1, round(image.height / scale))
-    return image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+    # Use PIL's thumbnail for correct aspect ratio preservation
+    image_copy = image.copy()
+    image_copy.thumbnail((max_dimension, max_dimension), resampling_method_id)
+    return image_copy
 
 
 def _ensure_rgb(image: PILImage) -> PILImage:
     return image.convert("RGB") if image.mode != "RGB" else image
 
 
-def _encode_from_image(image: PILImage, x_components: int = 4, y_components: int = 4, max_dimension: int = 64) -> str:
-    """Internal function to encode a PIL Image to BlurHash.
-
-    Args:
-        image (PILImage): Image to encode.
-        x_components (int): Number of horizontal components (1-9).
-        y_components (int): Number of vertical components (1-9).
-        max_dimension (int): Maximum dimension for resizing.
-
-    Returns:
-        str: BlurHash string.
-
-    Raises:
-        BlurHashEncodeError: If encoding fails or dimensions are invalid.
-        ValueError: If component values are out of range.
-    """
-    # Validate components
+def _validate_component_values(x_components: int, y_components: int) -> None:
     if not 1 <= x_components <= MAX_COMPONENTS_SIZE:
         msg = f"x_components must be between 1 and 9, got {x_components}"
         raise ValueError(msg)
     if not 1 <= y_components <= MAX_COMPONENTS_SIZE:
         msg = f"y_components must be between 1 and 9, got {y_components}"
         raise ValueError(msg)
+
+
+def _encode_from_image(
+    image: PILImage,
+    x_components: int = 4,
+    y_components: int = 3,
+    max_dimension: float = 64,
+    resampling_method: ResamplingMethod = "lanczos",
+) -> str:
+    """Internal function to encode a PIL Image to BlurHash.
+
+    Args:
+        image (PILImage): Image to encode.
+        x_components (int): Number of horizontal components (1-9).
+        y_components (int): Number of vertical components (1-9).
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension.
+        resampling_method (ResamplingMethod): Resampling method for resizing.
+
+    Returns:
+        str: BlurHash string.
+
+    Raises:
+        BlurHashEncodeError: If encoding fails or dimensions are invalid.
+        ValueError: If component values are out of range, If max_dimension is not positive,
+        or if the resampling method value is invalid.
+    """
+    # Validate components
+    _validate_component_values(x_components, y_components)
 
     rgb_image = _ensure_rgb(image)
 
@@ -136,26 +182,34 @@ def _encode_from_image(image: PILImage, x_components: int = 4, y_components: int
         raise BlurHashEncodeError(msg)
 
     # Resize
-    resized_image = _resize_image_if_needed(rgb_image, max_dimension)
+    resized_image = _downsample_image_if_needed(rgb_image, max_dimension, resampling_method)
 
     # Convert to numpy array and encode
     image_array = np.array(resized_image)
     return str(blurhash.encode(image_array, x_components, y_components))
 
 
-def _encode_pdu_from_image(image: PILImage, max_dimension: int = 64) -> str:
+def _encode_pdu_from_image(
+    image: PILImage,
+    max_dimension: float = 64,
+    resampling_method: ResamplingMethod = "lanczos",
+) -> str:
     """Internal function to encode a PIL Image to PNG data URL.
 
     Args:
-        image (PILImage): Image to encode.
-        max_dimension (int): Maximum dimension for resizing.
+        image (PILImage): Image to encode. (Any source image is converted to 8-bit sRGB before processing.)
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension.
+        resampling_method (ResamplingMethod): Resampling method to use when resizing.
 
     Returns:
         str: PNG data URL string.
 
     Raises:
         AvifPngDataUrlError: If encoding fails or dimensions are invalid.
-        ValueError: If max_dimension is not positive.
+        ValueError: If max_dimension is not positive, If max_dimension is not positive,
+        or if the resampling method value is invalid.
     """
     # Validate max_dimension
     if max_dimension <= 0:
@@ -168,12 +222,12 @@ def _encode_pdu_from_image(image: PILImage, max_dimension: int = 64) -> str:
         msg = f"Invalid image dimensions: {rgb_image.width}x{rgb_image.height}"
         raise AvifPngDataUrlError(msg)
 
-    resized_image = _resize_image_if_needed(rgb_image, max_dimension)
+    resized_image = _downsample_image_if_needed(rgb_image, max_dimension, resampling_method)
 
     # Encode to PNG in memory
-    buffer = BytesIO()
-    resized_image.save(buffer, format="PNG", optimize=True)
-    png_bytes = buffer.getvalue()
+    with BytesIO() as buffer:
+        resized_image.save(buffer, format="PNG", optimize=True)
+        png_bytes = buffer.getvalue()
 
     if not png_bytes:
         msg = "Failed to encode image to PNG: empty result"
@@ -183,112 +237,7 @@ def _encode_pdu_from_image(image: PILImage, max_dimension: int = 64) -> str:
     return f"data:image/png;base64,{base64_png}"
 
 
-def encode(image_path: str | Path, x_components: int = 4, y_components: int = 4, max_dimension: int = 64) -> str:
-    """Generates a BlurHash string for an AVIF image.
-
-    The image is resized to a maximum dimension of 64 pixels before encoding by default
-    to optimize performance while maintaining visual quality.
-
-    Args:
-        image_path (str | Path): Path to the AVIF image file.
-        x_components (int): Number of horizontal components (1-9, default: 4).
-        y_components (int): Number of vertical components (1-9, default: 4).
-        max_dimension (int): Maximum dimension of the resized image (default: 64).
-
-    Returns:
-        str: The BlurHash string representation of the image.
-
-    Raises:
-        PathError: If the image path is invalid or doesn't exist.
-        BlurHashEncodeError: If the dimensions are invalid.
-        ValueError: If component values are out of valid range.
-        OSError: If the image cannot be opened.
-    """
-    path_obj = _validate_and_resolve_path(image_path)
-
-    try:
-        with Image.open(path_obj) as original_image:
-            return _encode_from_image(original_image, x_components, y_components, max_dimension)
-    except OSError as e:
-        msg = f"Failed to open image file: {path_obj}. Original error: {e}"
-        raise OSError(msg) from e
-
-
-def encode_pdu(image_path: str | Path, max_dimension: int = 64) -> str:
-    """Generates a base64-encoded PNG data URL for an AVIF image.
-
-    The image is resized to the specified maximum dimension to create
-    a lightweight preview suitable for inline embedding.
-
-    Args:
-        image_path (str | Path): Path to the AVIF image file.
-        max_dimension (int): Maximum width/height for the thumbnail (default: 64).
-
-    Returns:
-        str: A data URL string in the format: data:image/png;base64,[base64-data]
-
-    Raises:
-        PathError: If the image path is invalid or doesn't exist.
-        AvifPngDataUrlError: If the image cannot be processed or encoded.
-        ValueError: If max_dimension is not positive.
-        OSError: If the image cannot be opened.
-    """
-    path_obj = _validate_and_resolve_path(image_path)
-
-    try:
-        with Image.open(path_obj) as original_image:
-            return _encode_pdu_from_image(original_image, max_dimension)
-    except OSError as e:
-        msg = f"Failed to open image file: {path_obj}. Original error: {e}"
-        raise AvifPngDataUrlError(msg) from e
-
-
-def encode_blurhash_and_pdu(
-    image_path: str | Path, x_components: int = 4, y_components: int = 4, max_dimension: int = 64
-) -> tuple[Optional[str], Optional[str]]:
-    """Generates both a BlurHash and a PNG data URL for an AVIF image.
-
-    This is a convenience function that performs both encodings in a single call.
-    The image is opened once and processed for both outputs. Errors in one encoding
-    don't prevent the other from being attempted.
-
-    Args:
-        image_path (str | Path): Path to the AVIF image file.
-        x_components (int): Number of horizontal BlurHash components (1-9, default: 4).
-        y_components (int): Number of vertical BlurHash components (1-9, default: 4).
-        max_dimension (int): Maximum dimension for resizing (default: 64).
-
-    Returns:
-        tuple[Optional[str], Optional[str]]: A tuple of (blurhash_string, png_data_url).
-            Either value may be None if its respective encoding fails.
-
-    Raises:
-        PathError: If the image path is invalid or doesn't exist.
-        OSError: If the image file cannot be opened.
-    """
-    path_obj = _validate_and_resolve_path(image_path)
-
-    blurhash_result = None
-    data_url_result = None
-
-    try:
-        with Image.open(path_obj) as original_image:
-            # Try BlurHash encoding
-            with contextlib.suppress(ValueError, BlurHashEncodeError):
-                blurhash_result = _encode_from_image(original_image, x_components, y_components, max_dimension)
-
-            # Try PNG data URL encoding
-            with contextlib.suppress(ValueError, AvifPngDataUrlError):
-                data_url_result = _encode_pdu_from_image(original_image, max_dimension)
-
-    except OSError as e:
-        msg = f"Failed to open image file: {path_obj}. Original error: {e}"
-        raise OSError(msg) from e
-
-    return blurhash_result, data_url_result
-
-
-def _validate_directory(directory: str | Path, skip_path_exists_check: bool = False) -> Path:
+def _validate_directory(directory: str | Path, skip_path_exists_check: bool = False) -> Path:  # noqa: FBT001, FBT002
     """Validate and convert directory to a Path object.
 
     Raises:
@@ -311,9 +260,141 @@ def _validate_directory(directory: str | Path, skip_path_exists_check: bool = Fa
     return directory_path
 
 
+def encode(
+    image_path: str | Path,
+    x_components: int = 4,
+    y_components: int = 3,
+    max_dimension: float = 64,
+    resampling_method: ResamplingMethod = "lanczos",
+) -> str:
+    """Generates a BlurHash string for an AVIF image.
+
+    The image is resized to a maximum dimension of 64 pixels before encoding by default
+    to optimize performance while maintaining visual quality.
+
+    Args:
+        image_path (str | Path): Path to the AVIF image file.
+        x_components (int): Number of horizontal components (1-9, default: 4).
+        y_components (int): Number of vertical components (1-9, default: 3).
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension..
+        resampling_method (ResamplingMethod): Resampling method to use for resizing (default: "lanczos").
+
+    Returns:
+        str: The BlurHash string representation of the image.
+
+    Raises:
+        PathError: If the image path is invalid or doesn't exist.
+        BlurHashEncodeError: If the dimensions are invalid.
+        ValueError: If component values are out of valid range.
+        OSError: If the image cannot be opened.
+    """
+    _validate_component_values(x_components, y_components)
+
+    path_obj = _validate_and_resolve_path(image_path, require_avif=True)
+
+    try:
+        with Image.open(path_obj) as original_image:
+            return _encode_from_image(original_image, x_components, y_components, max_dimension, resampling_method)
+    except OSError as e:
+        msg = f"Failed to open image file: {path_obj}. Original error: {e}"
+        raise OSError(msg) from e
+
+
+def encode_pdu(
+    image_path: str | Path, max_dimension: float = 64, resampling_method: ResamplingMethod = "lanczos"
+) -> str:
+    """Generates a base64-encoded PNG data URL for an AVIF image.
+
+    The image is resized to the specified maximum dimension to create
+    a lightweight preview suitable for inline embedding.
+
+    Args:
+        image_path (str | Path): Path to the AVIF image file.
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension.
+        resampling_method (ResamplingMethod): Resampling method to use when resizing the image (default: "lanczos").
+
+    Returns:
+        str: A data URL string in the format: data:image/png;base64,[base64-data]
+
+    Raises:
+        PathError: If the image path is invalid or doesn't exist.
+        AvifPngDataUrlError: If the image cannot be processed or encoded.
+        ValueError: If max_dimension is not positive.
+        OSError: If the image cannot be opened.
+    """
+    path_obj = _validate_and_resolve_path(image_path)
+
+    try:
+        with Image.open(path_obj) as original_image:
+            return _encode_pdu_from_image(original_image, max_dimension, resampling_method)
+    except OSError as e:
+        msg = f"Failed to open image file: {path_obj}. Original error: {e}"
+        raise AvifPngDataUrlError(msg) from e
+
+
+def encode_blurhash_and_pdu(
+    image_path: str | Path,
+    x_components: int = 4,
+    y_components: int = 3,
+    max_dimension: float = 64,
+    resampling_method: ResamplingMethod = "lanczos",
+) -> tuple[str | None, str | None]:
+    """Generates both a BlurHash and a PNG data URL for an AVIF image.
+
+    This is a convenience function that performs both encodings in a single call.
+    The image is opened once and processed for both outputs. Errors in one encoding
+    don't prevent the other from being attempted.
+
+    Args:
+        image_path (str | Path): Path to the AVIF image file.
+        x_components (int): Number of horizontal BlurHash components (1-9, default: 4).
+        y_components (int): Number of vertical BlurHash components (1-9, default: 4).
+        max_dimension (float): Maximum dimension for resizing (default: 64).
+        resampling_method (ResamplingMethod): Resampling method for resizing (default: "lanczos").
+
+    Returns:
+        tuple[Optional[str], Optional[str]]: A tuple of (blurhash_string, png_data_url).
+            Either value may be None if its respective encoding fails.
+
+    Raises:
+        PathError: If the image path is invalid or doesn't exist.
+        OSError: If the image file cannot be opened.
+    """
+    path_obj = _validate_and_resolve_path(image_path)
+
+    blurhash_result = None
+    data_url_result = None
+
+    try:
+        with Image.open(path_obj) as original_image:
+            # Try BlurHash encoding
+            with contextlib.suppress(ValueError, BlurHashEncodeError):
+                blurhash_result = _encode_from_image(
+                    original_image, x_components, y_components, max_dimension, resampling_method
+                )
+
+            # Try PNG data URL encoding
+            with contextlib.suppress(ValueError, AvifPngDataUrlError):
+                data_url_result = _encode_pdu_from_image(original_image, max_dimension, resampling_method)
+
+    except OSError as e:
+        msg = f"Failed to open image file: {path_obj}. Original error: {e}"
+        raise OSError(msg) from e
+
+    return blurhash_result, data_url_result
+
+
 def batch_encode(
-    directory: str | Path, skip_path_exists_check: bool = False, x_components: int = 4, y_components: int = 4
-) -> dict[str, Optional[str]]:
+    directory: str | Path,
+    x_components: int = 4,
+    y_components: int = 3,
+    skip_path_exists_check: bool = False,  # noqa: FBT001, FBT002
+    raise_on_error: bool = False,  # noqa: FBT001, FBT002
+) -> dict[str, str | None]:
     """Generates BlurHash strings for all AVIF images in a directory.
 
     Args:
@@ -321,6 +402,7 @@ def batch_encode(
         skip_path_exists_check (bool): If True, skip directory existence check (default: False).
         x_components (int): Number of horizontal components (1-9, default: 4).
         y_components (int): Number of vertical components (1-9, default: 4).
+        raise_on_error (bool): If True, raise an exception on error (default: False).
 
     Returns:
         dict[str, Optional[str]]: Dictionary mapping filenames to their BlurHash strings.
@@ -330,29 +412,38 @@ def batch_encode(
         PathError: If the directory path is invalid or doesn't exist
             (unless skip_path_exists_check is True).
     """
+    _validate_component_values(x_components, y_components)
     directory_path = _validate_directory(directory, skip_path_exists_check=skip_path_exists_check)
 
-    result: dict[str, Optional[str]] = {}
+    result: dict[str, str | None] = {}
 
     for image_path in directory_path.glob("*.avif"):
         try:
             blurhash_str = encode(image_path, x_components, y_components)
             result[image_path.name] = blurhash_str
         except (BlurHashEncodeError, PathError, ValueError, OSError):  # noqa: PERF203
+            if raise_on_error:
+                raise
             result[image_path.name] = None
 
     return result
 
 
 def batch_encode_pdu(
-    directory: str | Path, skip_path_exists_check: bool = False, max_dimension: int = 64
-) -> dict[str, Optional[str]]:
+    directory: str | Path,
+    max_dimension: float = 64,
+    skip_path_exists_check: bool = False,  # noqa: FBT001, FBT002
+    raise_on_error: bool = False,  # noqa: FBT001, FBT002
+) -> dict[str, str | None]:
     """Generates PNG data URLs for all AVIF images in a directory.
 
     Args:
         directory (str | Path): Path to the directory containing AVIF images.
         skip_path_exists_check (bool): If True, skip directory existence check (default: False).
-        max_dimension (int): Maximum dimension for thumbnails (default: 64).
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension.
+        raise_on_error (bool): If True, raise an exception on error (default: False).
 
     Returns:
         dict[str, Optional[str]]: Dictionary mapping filenames to their PNG data URLs.
@@ -364,25 +455,28 @@ def batch_encode_pdu(
     """
     directory_path = _validate_directory(directory, skip_path_exists_check=skip_path_exists_check)
 
-    result: dict[str, Optional[str]] = {}
+    result: dict[str, str | None] = {}
 
     for image_path in directory_path.glob("*.avif"):
         try:
             data_url = encode_pdu(image_path, max_dimension)
             result[image_path.name] = data_url
         except (AvifPngDataUrlError, PathError, ValueError, OSError):  # noqa: PERF203
+            if raise_on_error:
+                raise
             result[image_path.name] = None
 
     return result
 
 
-def batch_encode_blurhash_and_pdu(
+def batch_encode_blurhash_and_pdu(  # noqa: PLR0917
     directory: str | Path,
-    skip_path_exists_check: bool = False,
     x_components: int = 4,
-    y_components: int = 4,
-    max_dimension: int = 64,
-) -> tuple[dict[str, Optional[str]], dict[str, Optional[str]]]:
+    y_components: int = 3,
+    max_dimension: float = 64,
+    skip_path_exists_check: bool = False,  # noqa: FBT001, FBT002
+    raise_on_error: bool = False,  # noqa: FBT001, FBT002
+) -> tuple[dict[str, str | None], dict[str, str | None]]:
     """Generates both BlurHash strings and PNG data URLs for all AVIF images.
 
     Args:
@@ -390,7 +484,10 @@ def batch_encode_blurhash_and_pdu(
         skip_path_exists_check (bool): If True, skip directory existence check (default: False).
         x_components (int): Number of horizontal BlurHash components (1-9, default: 4).
         y_components (int): Number of vertical BlurHash components (1-9, default: 4).
-        max_dimension (int): Maximum dimension for PNG thumbnails (default: 64).
+        max_dimension (float): This is the max size a single edge of the image can be in pixels,
+                               when an image edge/side exceeds this value, the image will be
+                               downsampled to fit within the maximum dimension.
+        raise_on_error (bool): If True, raise an exception on error (default: False).
 
     Returns:
         tuple[dict[str, Optional[str]], dict[str, Optional[str]]]: A tuple of two dictionaries:
@@ -402,10 +499,11 @@ def batch_encode_blurhash_and_pdu(
         PathError: If the directory path is invalid or doesn't exist
             (unless skip_path_exists_check is True).
     """
+    _validate_component_values(x_components, y_components)
     directory_path = _validate_directory(directory, skip_path_exists_check=skip_path_exists_check)
 
-    blurhash_dict: dict[str, Optional[str]] = {}
-    data_url_dict: dict[str, Optional[str]] = {}
+    blurhash_dict: dict[str, str | None] = {}
+    data_url_dict: dict[str, str | None] = {}
 
     for image_path in directory_path.glob("*.avif"):
         try:
@@ -413,13 +511,15 @@ def batch_encode_blurhash_and_pdu(
             blurhash_dict[image_path.name] = blurhash_str
             data_url_dict[image_path.name] = data_url
         except (PathError, OSError):  # noqa: PERF203
+            if raise_on_error:
+                raise
             blurhash_dict[image_path.name] = None
             data_url_dict[image_path.name] = None
 
     return blurhash_dict, data_url_dict
 
 
-def is_valid_blurhash(blurhash_string: str) -> bool:
+def _simple_blurhash_validation(blurhash_string: str) -> bool:
     """Check if a string appears to be a valid BlurHash."""
     if not blurhash_string or len(blurhash_string) < 6:  # noqa: PLR2004
         return False
@@ -428,14 +528,18 @@ def is_valid_blurhash(blurhash_string: str) -> bool:
     return all(c in valid_chars for c in blurhash_string)
 
 
-def decode_to_pil_format(blurhash_string: str, width: int, height: int, punch: float = 1.0) -> PILImage:
+def decode_to_pil_format(blurhash_string: str, width: float, height: float, punch: float = 1.0) -> PILImage:
     """Decode a BlurHash string into a PIL Image object.
 
     Args:
         blurhash_string (str): The BlurHash string to decode.
-        width (int): The desired width of the output image (must be positive).
-        height (int): The desired height of the output image (must be positive).
-        punch (float): Contrast modifier (default: 1.0, higher = more contrast).
+        width (float): The desired width of the output image (must be positive).
+        height (float): The desired height of the output image (must be positive).
+        punch (float): Contrast adjustment factor (default: 1.0).
+                    - Values < 1.0 reduce contrast (softer, more blurred)
+                    - Values > 1.0 increase contrast (sharper, more defined)
+                    - Typical range: 0.5 to 2.0
+                    - Must be positive
 
     Returns:
         PILImage: A PIL Image object decoded from the BlurHash string.
@@ -448,7 +552,7 @@ def decode_to_pil_format(blurhash_string: str, width: int, height: int, punch: f
         msg = "BlurHash string cannot be empty"
         raise ValueError(msg)
 
-    if not is_valid_blurhash(blurhash_string):
+    if not _simple_blurhash_validation(blurhash_string):
         msg = f"BlurHash string appears to be invalid format: {blurhash_string[:20]}..."
         raise ValueError(msg)
 
@@ -465,11 +569,7 @@ def decode_to_pil_format(blurhash_string: str, width: int, height: int, punch: f
         raise ValueError(msg)
 
     try:
-        decoded = blurhash.decode(blurhash_string, width, height, punch=punch)
-
-        if decoded is None:
-            msg = "Decoder returned None"
-            raise BlurHashDecodeError(msg)
+        decoded: list[list[int]] = blurhash.decode(blurhash_string, width, height, punch=punch)
 
         image_array = np.array(decoded, dtype=np.uint8)
 
@@ -484,7 +584,7 @@ def decode_to_pil_format(blurhash_string: str, width: int, height: int, punch: f
         raise BlurHashDecodeError(msg) from e
 
 
-def save_image_png(image: PILImage, filename: str | Path, optimize: bool = True, interlaced: bool = True) -> None:
+def save_image_png(image: PILImage, filename: str | Path, *, optimize: bool = True, interlaced: bool = True) -> None:
     """Save a PIL Image to a PNG file with optional optimization.
 
     Args:
@@ -497,8 +597,8 @@ def save_image_png(image: PILImage, filename: str | Path, optimize: bool = True,
         ValueError: If the image or filename is invalid.
         ImageSaveError: If the image cannot be saved.
     """
-    if image is None:
-        msg = "Image cannot be None"
+    if not image:
+        msg = "Image cannot be empty"
         raise ValueError(msg)
 
     if not filename:
@@ -530,18 +630,20 @@ def save_image_png(image: PILImage, filename: str | Path, optimize: bool = True,
     except OSError as e:
         msg = f"Failed to save image to {path_obj}: {e!s}"
         raise ImageSaveError(msg) from e
+    except ValueError as e:
+        msg = f"Invalid image data: {e}"
+        raise ImageSaveError(msg) from e
 
 
 def decode(  # noqa: PLR0917
     output_path: str | Path,
     blurhash_string: str,
     filename: str = "output.png",
-    width: int = 400,
-    height: int = 300,
+    width: float = 400,
+    height: float = 300,
     punch: float = 1.0,
-    optimize: bool = True,
-    interlaced: bool = True,
-    verbose: bool = False,
+    optimize: bool = True,  # noqa: FBT001, FBT002
+    interlaced: bool = True,  # noqa: FBT001, FBT002
 ) -> None:
     """Decode a BlurHash string and save it as a PNG file.
 
@@ -549,12 +651,15 @@ def decode(  # noqa: PLR0917
         output_path (str | Path): Directory where the decoded image will be saved.
         blurhash_string (str): The BlurHash string to decode.
         filename (str): Output filename (default: "output.png").
-        width (int): Output image width in pixels (default: 400).
-        height (int): Output image height in pixels (default: 300).
-        punch (float): Contrast modifier (default: 1.0, higher = more contrast).
+        width (float): Output image width in pixels (default: 400).
+        height (float): Output image height in pixels (default: 300).
+        punch (float): Contrast adjustment factor (default: 1.0).
+                    - Values < 1.0 reduce contrast (softer, more blurred)
+                    - Values > 1.0 increase contrast (sharper, more defined)
+                    - Typical range: 0.5 to 2.0
+                    - Must be positive
         optimize (bool): If True, optimize the PNG file size (default: True).
         interlaced (bool): If True, save as interlaced PNG using Adam7 (default: True).
-        verbose (bool): If True, print success message (default: False).
 
     Raises:
         ValueError: If parameters are invalid.
@@ -580,7 +685,4 @@ def decode(  # noqa: PLR0917
 
     output_filename = output_path_obj / filename.replace(".avif", ".png")
 
-    save_image_png(decoded_image, output_filename, optimize, interlaced)
-
-    if verbose:
-        print(f"Successfully decoded and saved: {output_filename}")
+    save_image_png(decoded_image, output_filename, optimize=optimize, interlaced=interlaced)

--- a/src/blurhash_avif/blurhash_avif.py
+++ b/src/blurhash_avif/blurhash_avif.py
@@ -80,7 +80,7 @@ def _validate_and_resolve_path(image_path: str | Path, *, require_avif: bool = F
         raise PathError(msg)
 
     if require_avif and path_obj.suffix.lower() != ".avif":
-        msg = f"Expected AVIF file, got: {path_obj.suffix}"
+        msg = f"Expected AVIF file Extension, got: {path_obj.suffix}"
         raise PathError(msg)
 
     return path_obj

--- a/src/blurhash_avif/blurhash_avif.py
+++ b/src/blurhash_avif/blurhash_avif.py
@@ -80,7 +80,7 @@ def _validate_and_resolve_path(image_path: str | Path, *, require_avif: bool = F
         raise PathError(msg)
 
     if require_avif and path_obj.suffix.lower() != ".avif":
-        msg = f"Expected AVIF file Extension, got: {path_obj.suffix}"
+        msg = f"Expected AVIF file extension, got: {path_obj.suffix}"
         raise PathError(msg)
 
     return path_obj
@@ -126,7 +126,7 @@ def _downsample_image_if_needed(
     if image.width <= max_dimension and image.height <= max_dimension:
         return image
 
-    # Use PIL's thumbnail for correct aspect ratio preservation
+    # Uses PIL's thumbnail for correct aspect ratio preservation
     image_copy = image.copy()
     image_copy.thumbnail((max_dimension, max_dimension), resampling_method_id)
     return image_copy

--- a/tests/test_blurhash_avif.py
+++ b/tests/test_blurhash_avif.py
@@ -8,6 +8,7 @@ try:
     from src.blurhash_avif import (
         AvifPngDataUrlError,
         PathError,
+        _simple_blurhash_validation,
         batch_encode,
         batch_encode_blurhash_and_pdu,
         batch_encode_pdu,
@@ -16,13 +17,13 @@ try:
         encode,
         encode_blurhash_and_pdu,
         encode_pdu,
-        is_valid_blurhash,
         save_image_png,
     )
 except ImportError:
     from blurhash_avif import (
         AvifPngDataUrlError,
         PathError,
+        _simple_blurhash_validation,  # noqa: PLC2701
         batch_encode,
         batch_encode_blurhash_and_pdu,
         batch_encode_pdu,
@@ -31,7 +32,6 @@ except ImportError:
         encode,
         encode_blurhash_and_pdu,
         encode_pdu,
-        is_valid_blurhash,
         save_image_png,
     )
 
@@ -365,7 +365,7 @@ class TestBlurhashAvif(unittest.TestCase):  # noqa: PLR0904
         ]
 
         for hash_str in valid_hashes:
-            self.assertTrue(is_valid_blurhash(hash_str), f"Failed for: {hash_str}")
+            self.assertTrue(_simple_blurhash_validation(hash_str), f"Failed for: {hash_str}")
 
     def test_is_valid_blurhash_invalid(self) -> None:
         """Test validation of invalid BlurHash strings."""
@@ -378,7 +378,7 @@ class TestBlurhashAvif(unittest.TestCase):  # noqa: PLR0904
 
         for hash_str in invalid_hashes:
             if hash_str is not None:
-                self.assertFalse(is_valid_blurhash(hash_str), f"Should fail for: {hash_str}")
+                self.assertFalse(_simple_blurhash_validation(hash_str), f"Should fail for: {hash_str}")
 
     # ===== Decoding Tests =====
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "blurhash-avif"
-version = "0.8.4"
+version = "0.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "blurhash" },


### PR DESCRIPTION
Refactor: Improve function docstrings and add resampling method

Fix: Add missing resampling method to the encode function.

Fix: Improve error messages in batch encode functions.

Fix: Rename is_valid_blurhash function to _simple_blurhash_validation

Fix: Fix max dimension for the image edge size to 65536.

Docs: Update the README and clarify the max_dimension.

Style: Remove redundant imports and improve formatting.

Refactor: remove verbose parameter from decode function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable resampling method for image downsampling.
  - Floating-point dimensions supported across encode/decode and batch operations.
  - Maximum AVIF image edge-size guardrail added.
  - Batch operations offer optional error-raising and clearer per-file results (returns str | None).

- Breaking Changes
  - Public validation helper replaced; previous validator removed.
  - Some defaults adjusted and certain parameters are now keyword-only.

- Documentation
  - README example updated with explicit result typing.

- Chores
  - Version bumped to 0.8.5; lint rules expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->